### PR TITLE
update all mentions of ADA to ada

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Major frameworks/libraries used in this project.
 
 # Cardano Reward Calculator
 This is a web interface where
-users can enter an ADA balance and calculate their potential rewards
+users can enter an ada balance and calculate their potential rewards
 based on current blockchain parameters and a representative staking pool.
 
 A demo is available <a href="https://dynamicstrategies.io/crewardcalculator">here</a>
@@ -76,7 +76,7 @@ The reward calculator is organized in 4 sections with increasing detail:
 
 ### 1. Basic Calculator
 Displays the calculator and allow the user to input values to determine the expected % annual yield and
-expected ADA return over a year
+expected ada return over a year
 
 <img src="public/images/calculator_printscreen.png" alt="Calculator prinstscreen" width="600">
 
@@ -97,7 +97,7 @@ stake and pledge).
 
 ### 4. Blockchain Parameters
 Show the static blockchain parameters
-(which can not be changed e.g. total supply of ADA) and the
+(which can not be changed e.g. total supply of ada) and the
 dynamic parameters (that can be changed through a governance
 vote and/or CIP e.g. the k and the a0 parameters). The user is
 able to change the dynamic parameters in the front-end and the
@@ -177,7 +177,7 @@ stake pool fees, gets distributed evenly amongst the delegators
 A few example might help understand the importance of stake pool size on the economics for
 stake pool operators and delegators
 
-**A medium-sized stake pool (10 to 20mn ADA stake)**
+**A medium-sized stake pool (10 to 20mn ada stake)**
 
 If a medium-sized stake pool minted 10 blocks during an epoch
 - each block is worth ~400 ada, then the 
@@ -189,7 +189,7 @@ If a medium-sized stake pool minted 10 blocks during an epoch
 So, in this stake pool, the pool
 operator receives 413.2 / 4000 = 10.3% of all rewards and the rest goes to the delegators *
 
-**A small stake pool ( <1mn ADA stake)**
+**A small stake pool ( <1mn ada stake)**
 
 If a small stake pool minted 1 block during an epoch
 - each block is worth ~400 ada, then the
@@ -201,7 +201,7 @@ If a small stake pool minted 1 block during an epoch
 So, in this stake pool, the pool
 operator receives 341.2 / 400 = 85.3% of all rewards and the rest goes to the delegators *
 
-**A large stake pool (>30mn ADA stake)**
+**A large stake pool (>30mn ada stake)**
 
 If a large stake pool minted 30 blocks during an epoch
 - each block is worth ~400 ada, then the

--- a/components/infos.js
+++ b/components/infos.js
@@ -8,7 +8,7 @@ export const uiText = {
 	"amount_ada_to_stake": {
 		"en": [
 			<div key="amount_ada_to_stake_en">
-				Amount of ADA to Stake
+				Amount of ada to Stake
 			</div>
 		],
 		"jp": [
@@ -21,7 +21,7 @@ export const uiText = {
 	"amount_ada_to_stake_desc": {
 		"en": [
 			<div key="amount_ada_to_stake_desc_en">
-				Input the amount of ADA that you are looking to stake
+				Input the amount of ada that you are looking to stake
 			</div>
 		],
 		"jp": [
@@ -47,7 +47,7 @@ export const uiText = {
 	"staking_rewards_per_year_ada_label": {
 		"en": [
 			<div key="staking_rewards_per_year_ada_label_en">
-				Staking Reward per Year ADA
+				Staking Reward per Year Ada
 			</div>
 		],
 		"jp": [
@@ -305,7 +305,7 @@ export const infoHovers = {
 		"en": [
 			<div key="pool_pledge_en" className="space-y-2">
 				<h4 className="text-lg font-medium">Pool Pledge</h4>
-				<p>The amount of ADA the stake pool operator commits to their own pool as a form of &quot;skin in the game&quot;.</p>
+				<p>The amount of ada the stake pool operator commits to their own pool as a form of &quot;skin in the game&quot;.</p>
 				<ul className="list-disc pl-6 space-y-2">
 					<li>Pools with higher pledges potentially earn slightly higher rewards through the &quot;a0&quot; parameter in the reward formula</li>
 					<li>Higher pledges show higher monetary commitments from the pool operator</li>
@@ -329,9 +329,9 @@ export const infoHovers = {
 		"en": [
 			<div key="delegator_stake_en" className="space-y-2">
 				<h4 className="text-lg font-medium">Delegators&apos; Stake</h4>
-				<p>The total amount of ADA that other users (delegators) have staked to this pool.</p>
+				<p>The total amount of ada that other users (delegators) have staked to this pool.</p>
 				<ul className="list-disc pl-6 space-y-2">
-					<li>The more ADA staked by delegators, the higher the pool’s likelihood of being selected to produce blocks and earning rewards.</li>
+					<li>The more ada staked by delegators, the higher the pool’s likelihood of being selected to produce blocks and earning rewards.</li>
 					<li>Pools with higher delegated stake tend to produce more blocks and generate more rewards, but this needs to be weighted aginst
 						the fees that they charge</li>
 				</ul>
@@ -353,8 +353,8 @@ export const infoHovers = {
 		"en": [
 			<div key="total_pool_stake_en" className="space-y-2">
 				<h4 className="text-lg font-medium">Total Pool Stake</h4>
-				<p>The combined amount of ADA in the pool, including the operator&apos;s pledge and the delegators&apos; stake.
-					This is the total ADA that the pool uses to participate in block production and earn rewards.</p>
+				<p>The combined amount of ada in the pool, including the operator&apos;s pledge and the delegators&apos; stake.
+					This is the total ada that the pool uses to participate in block production and earn rewards.</p>
 				<p>Pools with higher stake will get to mint more blocks and receive more fees. These fees will need to be
 					split between the pool operator and all the delegators.</p>
 			</div>
@@ -482,7 +482,7 @@ export const infoHovers = {
 			<div key="a0_en" className="space-y-2">
 				<h4 className="text-lg font-medium">a0 - Pledge Influence Factor</h4>
 				<p>Determines how much the size of a stake pool&apos;s pledge influences the rewards distribution.
-					It serves as an incentive mechanism to encourage stake pool operators to pledge more ADA to their pools.</p>
+					It serves as an incentive mechanism to encourage stake pool operators to pledge more ada to their pools.</p>
 			</div>
 		],
 		"jp": [
@@ -619,7 +619,7 @@ export const infoHovers = {
 	"reserve_ada": {
 		"en": [
 			<div key="reserve_ada_en" className="space-y-2">
-				<h4 className="text-lg font-medium">Reserve ADA</h4>
+				<h4 className="text-lg font-medium">Reserve Ada</h4>
 				<p>...</p>
 			</div>
 		],
@@ -634,7 +634,7 @@ export const infoHovers = {
 	"total_staked_ada": {
 		"en": [
 			<div key="total_staked_ada_en" className="space-y-2">
-				<h4 className="text-lg font-medium">Total Staked ADA</h4>
+				<h4 className="text-lg font-medium">Total Staked Ada</h4>
 				<p>...</p>
 			</div>
 		],
@@ -649,7 +649,7 @@ export const infoHovers = {
 	"fees_in_epoch": {
 		"en": [
 			<div key="fees_in_epoch_en" className="space-y-2">
-				<h4 className="text-lg font-medium">ADA Fees in an Epoch</h4>
+				<h4 className="text-lg font-medium">Ada Fees in an Epoch</h4>
 				<p>...</p>
 			</div>
 		],
@@ -664,7 +664,7 @@ export const infoHovers = {
 	"distribution_from_reserve": {
 		"en": [
 			<div key="distribution_from_reserve_en" className="space-y-2">
-				<h4 className="text-lg font-medium">ADA Distributed from Reserve</h4>
+				<h4 className="text-lg font-medium">Ada Distributed from Reserve</h4>
 				<p>A portion (rho) is distributed from Cardano Reserve to pay for Staking Rewards each Epoch. This number will reduce gradually over time
 					as the amount in the Reserve gets depleted. To maintain the same level of staking rewards the rewards from Fees will need to rise.</p>
 				<p>Change the Rho parameter to see how this affects the total reward to delegators</p>
@@ -768,7 +768,7 @@ export const infoHovers = {
 
 /**
  * These are the info boxes placed next to the large sections of the calculator
- * - Amount of ADA to sake (section 1)
+ * - Amount of ada to sake (section 1)
  * - Stake Pools (section 2)
  * - Stake Pool Parameters (section 3)
  * - Blockchain Parameters (section 4)

--- a/createReactApp/src/App.js
+++ b/createReactApp/src/App.js
@@ -206,7 +206,7 @@ export default class App extends React.Component {
 	 * - Gets the Blockchain protocol parameters (rho - monetaryExpansion;
 	 * tau - treasuryCut; k - stakePoolTargetNum; a0 - poolPledgeInfluence)
 	 *
-	 * - Get the Current Ada supply (not all of 45b ADA has been released)
+	 * - Get the Current Ada supply (not all of 45b ada has been released)
 	 *
 	 * - Gets the basic information on all stake pools. This is then used
 	 * for a user to select more info a particular stake pool
@@ -918,10 +918,10 @@ export default class App extends React.Component {
 							{/* Row 1, Column 1 */}
 							<div className="border border-gray-300 shadow-md rounded-lg bg-white p-8 lg:col-span-2">
 								<h4 className="text-balance text-2xl font-medium tracking-tight text-gray-900">
-									Amount of ADA to Stake
+									Amount of ada to Stake
 								</h4>
 
-								<p className="mt-2">Input the amount of ADA that you are looking to stake</p>
+								<p className="mt-2">Input the amount of ada that you are looking to stake</p>
 
 								<div className="mt-8 grid gap-4 overflow-hidden text-center">
 
@@ -934,7 +934,7 @@ export default class App extends React.Component {
 											onChange={this.handleChange}
 											value={this.state.userAmount.toLocaleString("en-US")}
 											fill={true}
-											rightElement={<Tag minimal={true}>ADA</Tag>}
+											rightElement={<Tag minimal={true}>ada</Tag>}
 										/>
 									</ControlGroup>
 
@@ -943,7 +943,7 @@ export default class App extends React.Component {
 
 										<div key="pool-reward-ada" className="flex flex-col bg-gray-700/5 p-8">
 											<div className="flex flex-row gap-2 justify-center mt-4 ">
-												<dt className="text-sm/6 font-semibold text-gray-600">Staking Reward per Year ADA</dt>
+												<dt className="text-sm/6 font-semibold text-gray-600">Staking Reward per Year Ada</dt>
 												<span className="mt-0.5">
 													<InfoHoverComponent>{infoHovers["staking_reward_per_year_ada"]}</InfoHoverComponent>
 												</span>
@@ -1271,7 +1271,7 @@ export default class App extends React.Component {
 											fill={true}
 											rightElement={
 											<div className="flex flex-row content-center">
-												<Tag minimal={true}>ADA</Tag>
+												<Tag minimal={true}>ada</Tag>
 												<span className="mt-1.5 mr-1"><InfoHoverComponent>{infoHovers["pool_pledge"]}</InfoHoverComponent></span>
 
 											</div>
@@ -1290,7 +1290,7 @@ export default class App extends React.Component {
 											fill={true}
 											rightElement={
 												<div className="flex flex-row content-center">
-													<Tag minimal={true}>ADA</Tag>
+													<Tag minimal={true}>ada</Tag>
 													<span className="mt-1.5 mr-1"><InfoHoverComponent>{infoHovers["delegator_stake"]}</InfoHoverComponent></span>
 												</div>
 											}
@@ -1308,7 +1308,7 @@ export default class App extends React.Component {
 											fill={true}
 											rightElement={
 												<div className="flex flex-row content-center">
-													<Tag minimal={true}>ADA</Tag>
+													<Tag minimal={true}>ada</Tag>
 													<span className="mt-1.5 mr-1"><InfoHoverComponent>{infoHovers["total_pool_stake"]}</InfoHoverComponent></span>
 												</div>
 											}
@@ -1326,7 +1326,7 @@ export default class App extends React.Component {
 											fill={true}
 											rightElement={
 												<div className="flex flex-row content-center">
-													<Tag minimal={true}>ADA</Tag>
+													<Tag minimal={true}>ada</Tag>
 													<span className="mt-1.5 mr-1"><InfoHoverComponent>{infoHovers["pool_fixed_costs"]}</InfoHoverComponent></span>
 												</div>
 											}
@@ -1581,7 +1581,7 @@ export default class App extends React.Component {
 										</ControlGroup>
 
 										<ControlGroup fill={true} vertical={false} style={{width:"90%"}}>
-											<Label htmlFor="max-ada-supply" style={{width:"400px"}}>Max ADA Supply</Label>
+											<Label htmlFor="max-ada-supply" style={{width:"400px"}}>Max Ada Supply</Label>
 											<InputGroup
 												id="max-ada-supply"
 												disabled={true}
@@ -1598,7 +1598,7 @@ export default class App extends React.Component {
 										</ControlGroup>
 
 										<ControlGroup fill={true} vertical={false} style={{width:"90%"}}>
-											<Label htmlFor="current-ada-supply" style={{width:"400px"}}>Current ADA Supply</Label>
+											<Label htmlFor="current-ada-supply" style={{width:"400px"}}>Current Ada Supply</Label>
 											<InputGroup
 												id="current-ada-supply"
 												disabled={false}
@@ -1616,7 +1616,7 @@ export default class App extends React.Component {
 										</ControlGroup>
 
 										<ControlGroup fill={true} vertical={false} style={{width:"90%"}}>
-											<Label htmlFor="reserve-ada" style={{width:"400px"}}>Reserve ADA</Label>
+											<Label htmlFor="reserve-ada" style={{width:"400px"}}>Reserve Ada</Label>
 											<InputGroup
 												id="reserve-ada"
 												disabled={true}

--- a/createReactApp/src/infos.js
+++ b/createReactApp/src/infos.js
@@ -26,7 +26,7 @@ export const infoHovers = {
 	"pool_pledge": [
 		<div className="space-y-2">
 			<h4 className="text-lg font-medium">Pool Pledge</h4>
-			<p>The amount of ADA the stake pool operator commits to their own pool as a form of "skin in the game".</p>
+			<p>The amount of ada the stake pool operator commits to their own pool as a form of "skin in the game".</p>
 			<ul className="list-disc pl-6 space-y-2">
 				<li>Pools with higher pledges potentially earn slightly higher rewards through the "a0" parameter in the reward formula</li>
 				<li>Higher pledges show higher monetary commitments from the pool operator</li>
@@ -38,9 +38,9 @@ export const infoHovers = {
 	"delegator_stake": [
 		<div className="space-y-2">
 			<h4 className="text-lg font-medium">Delegators' Stake</h4>
-			<p>The total amount of ADA that other users (delegators) have staked to this pool.</p>
+			<p>The total amount of ada that other users (delegators) have staked to this pool.</p>
 			<ul className="list-disc pl-6 space-y-2">
-				<li>The more ADA staked by delegators, the higher the pool’s likelihood of being selected to produce blocks and earning rewards.</li>
+				<li>The more ada staked by delegators, the higher the pool’s likelihood of being selected to produce blocks and earning rewards.</li>
 				<li>Pools with higher delegated stake tend to produce more blocks and generate more rewards, but this needs to be weighted aginst
 				the fees that they charge</li>
 			</ul>
@@ -50,8 +50,8 @@ export const infoHovers = {
 	"total_pool_stake": [
 		<div className="space-y-2">
 			<h4 className="text-lg font-medium">Total Pool Stake</h4>
-			<p>The combined amount of ADA in the pool, including the operator's pledge and the delegators' stake.
-				This is the total ADA that the pool uses to participate in block production and earn rewards.</p>
+			<p>The combined amount of ada in the pool, including the operator's pledge and the delegators' stake.
+				This is the total ada that the pool uses to participate in block production and earn rewards.</p>
 			<p>Pools with higher stake will get to mint more blocks and receive more fees. These fees will need to be
 			split between the pool operator and all the delegators.</p>
 		</div>
@@ -106,7 +106,7 @@ export const infoHovers = {
 		<div className="space-y-2">
 			<h4 className="text-lg font-medium">a0 - Pledge Influence Factor</h4>
 			<p>Determines how much the size of a stake pool's pledge influences the rewards distribution.
-				It serves as an incentive mechanism to encourage stake pool operators to pledge more ADA to their pools.</p>
+				It serves as an incentive mechanism to encourage stake pool operators to pledge more ada to their pools.</p>
 		</div>
 	],
 
@@ -168,28 +168,28 @@ export const infoHovers = {
 
 	"reserve_ada": [
 		<div className="space-y-2">
-			<h4 className="text-lg font-medium">Reserve ADA</h4>
+			<h4 className="text-lg font-medium">Reserve Ada</h4>
 			<p>...</p>
 		</div>
 	],
 
 	"total_staked_ada": [
 		<div className="space-y-2">
-			<h4 className="text-lg font-medium">Total Staked ADA</h4>
+			<h4 className="text-lg font-medium">Total Staked Ada</h4>
 			<p>...</p>
 		</div>
 	],
 
 	"fees_in_epoch": [
 		<div className="space-y-2">
-			<h4 className="text-lg font-medium">ADA Fees in an Epoch</h4>
+			<h4 className="text-lg font-medium">Ada Fees in an Epoch</h4>
 			<p>...</p>
 		</div>
 	],
 
 	"distribution_from_reserve": [
 		<div className="space-y-2">
-			<h4 className="text-lg font-medium">ADA Distributed from Reserve</h4>
+			<h4 className="text-lg font-medium">Ada Distributed from Reserve</h4>
 			<p>A portion (rho) is distributed from Cardano Reserve to pay for Staking Rewards each Epoch. This number will reduce gradually over time
 				as the amount in the Reserve gets depleted. To maintain the same level of staking rewards the rewards from Fees will need to rise.</p>
 			<p>Change the Rho parameter to see how this affects the total reward to delegators</p>
@@ -219,8 +219,8 @@ export const infoHovers = {
 
 	"staking_reward_per_year_ada": [
 		<div className="space-y-2">
-			<h4 className="text-lg font-medium">Staking Reward per Year ADA</h4>
-			<p>Expected reward in ADA per year for the amount staked.</p>
+			<h4 className="text-lg font-medium">Staking Reward per Year Ada</h4>
+			<p>Expected reward in ada per year for the amount staked.</p>
 			<p>Number in grey shows the result from the previous simulation, for comparability between simulations with different parameters</p>
 		</div>
 	],
@@ -237,7 +237,7 @@ export const infoHovers = {
 
 /**
  * These are the info boxes placed next to the large sections of the calculator
- * - Amount of ADA to sake (section 1)
+ * - Amount of ada to sake (section 1)
  * - Stake Pools (section 2)
  * - Stake Pool Parameters (section 3)
  * - Blockchain Parameters (section 4)

--- a/pages/index.js
+++ b/pages/index.js
@@ -1068,7 +1068,7 @@ class RewardCalculator extends React.Component {
                           }}
                           value={this.state.userAmount.toLocaleString("en-US")}
                           fill={true}
-                          rightElement={<Tag minimal={true}>ADA</Tag>}
+                          rightElement={<Tag minimal={true}>ada</Tag>}
                       />
                     </ControlGroup>
 
@@ -1420,7 +1420,7 @@ class RewardCalculator extends React.Component {
                               fill={true}
                               rightElement={
                                 <div className="flex flex-row content-center">
-                                  <Tag minimal={true}>ADA</Tag>
+                                  <Tag minimal={true}>ada</Tag>
                                   <span className="mt-1.5 mr-1"><InfoHoverComponent>{infoHovers["pool_pledge"][this.state.lang]}</InfoHoverComponent></span>
 
                                 </div>
@@ -1443,7 +1443,7 @@ class RewardCalculator extends React.Component {
                               fill={true}
                               rightElement={
                                 <div className="flex flex-row content-center">
-                                  <Tag minimal={true}>ADA</Tag>
+                                  <Tag minimal={true}>ada</Tag>
                                   <span className="mt-1.5 mr-1"><InfoHoverComponent>{infoHovers["delegator_stake"][this.state.lang]}</InfoHoverComponent></span>
                                 </div>
                               }
@@ -1465,7 +1465,7 @@ class RewardCalculator extends React.Component {
                               fill={true}
                               rightElement={
                                 <div className="flex flex-row content-center">
-                                  <Tag minimal={true}>ADA</Tag>
+                                  <Tag minimal={true}>ada</Tag>
                                   <span className="mt-1.5 mr-1"><InfoHoverComponent>{infoHovers["total_pool_stake"][this.state.lang]}</InfoHoverComponent></span>
                                 </div>
                               }
@@ -1487,7 +1487,7 @@ class RewardCalculator extends React.Component {
                               fill={true}
                               rightElement={
                                 <div className="flex flex-row content-center">
-                                  <Tag minimal={true}>ADA</Tag>
+                                  <Tag minimal={true}>ada</Tag>
                                   <span className="mt-1.5 mr-1"><InfoHoverComponent>{infoHovers["pool_fixed_costs"][this.state.lang]}</InfoHoverComponent></span>
                                 </div>
                               }
@@ -1772,7 +1772,7 @@ class RewardCalculator extends React.Component {
                             />
                           </div>
 
-                          <div className="col-span-2 mt-2 sm:mt-0">Max ADA Supply</div>
+                          <div className="col-span-2 mt-2 sm:mt-0">Max Ada Supply</div>
                           <div className="col-span-4">
                             <InputGroup
                                 id="max-ada-supply"
@@ -1788,7 +1788,7 @@ class RewardCalculator extends React.Component {
                             />
                           </div>
 
-                          <div className="col-span-2 mt-2 sm:mt-0">Current ADA Supply</div>
+                          <div className="col-span-2 mt-2 sm:mt-0">Current Ada Supply</div>
                           <div className="col-span-4">
                             <InputGroup
                                 id="current-ada-supply"
@@ -1808,7 +1808,7 @@ class RewardCalculator extends React.Component {
                             />
                           </div>
 
-                          <div className="col-span-2 mt-2 sm:mt-0">Reserve ADA</div>
+                          <div className="col-span-2 mt-2 sm:mt-0">Reserve Ada</div>
                           <div className="col-span-4">
                             <InputGroup
                                 id="reserve-ada"
@@ -1824,7 +1824,7 @@ class RewardCalculator extends React.Component {
                             />
                           </div>
 
-                          <div className="col-span-2 mt-2 sm:mt-0">Total Staked ADA</div>
+                          <div className="col-span-2 mt-2 sm:mt-0">Total Staked Ada</div>
                           <div className="col-span-4">
                             <InputGroup
                                 id="total-staked-ada"


### PR DESCRIPTION
As per guidelines on https://cardano.org/docs/glossary#cardano-glossary

When talking about the cryptocurrency, do not capitalize, unless at the beginning of a sentence. The idea behind this is to treat it like dollars or euros. If you are in doubt, in English, prefer ada over ADA. Capitalised ADA stands for the ticker symbol only.